### PR TITLE
feat: adds initial positions of stimuli in .timestamps files

### DIFF
--- a/src/units/constants.pas
+++ b/src/units/constants.pas
@@ -383,6 +383,15 @@ resourcestring
   rsReportTrialID = 'Tentativa.ID';
   rsReportTrialNO = 'Tentativa.Contador';
   rsReportTrialName = 'Tentativa.Nome';
+  rsReportA1Position = 'A1.Posicao.Inicial';
+  rsReportA2Position = 'A2.Posicao.Inicial';
+  rsReportA3Position = 'A3.Posicao.Inicial';
+  rsReportB1Position = 'B1.Posicao.Inicial';
+  rsReportB2Position = 'B2.Posicao.Inicial';
+  rsReportB3Position = 'B3.Posicao.Inicial';
+  rsReportC1Position = 'C1.Posicao.Inicial';
+  rsReportC2Position = 'C2.Posicao.Inicial';
+  rsReportC3Position = 'C3.Posicao.Inicial';
   rsReportEvent = 'Evento';
   rsReportITIBeg = 'IET.Inicio';
   rsReportITIEnd = 'IET.Fim';

--- a/src/units/controls.trials.abstract.pas
+++ b/src/units/controls.trials.abstract.pas
@@ -523,6 +523,15 @@ begin
                       rsReportTrialID + #9 +
                       rsReportTrialNO + #9 +
                       rsReportTrialName + #9 +
+                      rsReportA1Position + #9 +
+                      rsReportA2Position + #9 +
+                      rsReportA3Position + #9 +
+                      rsReportB1Position + #9 +
+                      rsReportB2Position + #9 +
+                      rsReportB3Position + #9 +
+                      rsReportC1Position + #9 +
+                      rsReportC2Position + #9 +
+                      rsReportC3Position + #9 +
                       rsReportEvent;
 end;
 


### PR DESCRIPTION
Este pull request representa a adição das posições iniciais correspondentes dos estímulos, tanto dos modelos quanto dos alvos, aos arquivos de relatórios de sessões .timestamps. Até o momento, foram incluídos apenas os cabeçalhos das posições iniciais dos estímulos, utilizando as novas constantes criadas.

@cpicanco, uma questão que surgiu foi a seguinte: com a adição desses novos cabeçalhos, a visualização do relatório pode se tornar menos clara, devido à presença de vários cabeçalhos no mesmo relatório. Como pode ser visto na imagem a seguir:
![relat](https://github.com/eep-lab/arrasta/assets/102481234/3b9518ae-463d-4a49-b886-f468fb254d94)

Uma ideia que tive e parece ser a mais adequada é relatar apenas as posições dos estímulos usados em cada sessão. Por exemplo, se apenas um único par de estímulos foi selecionado, o relatório conterá apenas as posições dos estímulos A1 e B1. No entanto, ainda procurarei formas de como implementar isso, já que estou me familiarizando mais com essa parte de manipulação de relatórios.

Além disso, é importante mencionar que esses cabeçalhos são, por enquanto, apenas um escopo inicial e podem sofrer alterações no futuro.
